### PR TITLE
merge_pcap: cleaning fix

### DIFF
--- a/merge_pcap.sh
+++ b/merge_pcap.sh
@@ -148,7 +148,5 @@ done
 echo "merging $NB_ITERATION files into $OUTPUT_FILE"
 mergecap -w "$OUTPUT_FILE" $PCAP_OUT*
 tshark -r $OUTPUT_FILE -w $WORK_DIR/tmp.pcap -F libpcap
-mv tmp.pcap $OUTPUT_FILE
 echo "cleaning"
-rm $WORK_DIR/*
-rm -r $WORK_DIR
+rm -r "$WORK_DIR"


### PR DESCRIPTION
The tmp.pcap moving should not be done because it is tshark that generates the output file. Furthermore, the path tmp.pcap was wrong. tmp.pcap is inside the "WORK_DIR" directory and not in the current directory.

Also, the `rm $WORK_DIR/*` was useless because the directory is removed afterward.