### PR TITLE
generate_pcap: fix SMP_CNT_OFFSET calculation

### DIFF
--- a/generate_pcap.py
+++ b/generate_pcap.py
@@ -268,7 +268,7 @@ SV_DATA = (
 TS_OFFSET = 0
 APP_ID_OFFSET = 0x1E + vlan_size
 SV_ID_OFFSET = 0x31 + vlan_size
-SMP_CNT_OFFSET = SV_ID_OFFSET + 2 + len(svIDFirst) + vlan_size
+SMP_CNT_OFFSET = SV_ID_OFFSET + 2 + len(svIDFirst)
 
 
 pcap_data = bytearray()


### PR DESCRIPTION
The SMP_CNT_OFFSET calculation was wrong because it was taking into account the vlan_size which was already added to the SV_ID_OFFSET.